### PR TITLE
easily switch between pigeon and NAVX

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -26,6 +26,9 @@ public final class Constants {
      */
     public static final double DRIVETRAIN_WHEELBASE_METERS = 1.0; // FIXME Measure and set wheelbase
 
+    /*
+     * Set pigeon ID to -1 to disable pigeon over CAN and use NAVX on SPI.Port.kMXP
+     * */
     public static final int DRIVETRAIN_PIGEON_ID = 0; // FIXME Set Pigeon ID
 
     public static final int FRONT_LEFT_MODULE_DRIVE_MOTOR = 0; // FIXME Set front left module drive motor ID


### PR DESCRIPTION
I added some code to make it easier to switch between using a pigeon IMU and the NAVX. This way you can change between the two by changing the CAN id in the Constants.java file instead of changing code in DrivetrainSubsystem.java.

Setting the pigeon CAN id to -1 automatically disables the pigeon and uses the NAVX for the gyro/IMU. I tested this on our robot that had both pigeon and NAVX. Behavior was identical.