### PR TITLE
Add hint that Mk4i modules must be used by the respective class and n…

### DIFF
--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -96,6 +96,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
     //   Your module has a NEO and a Falcon 500 on it. The NEO is for driving and the Falcon 500 is for steering.
     //
     // Similar helpers also exist for Mk4 modules using the Mk4SwerveModuleHelper class.
+    // This means that you can also use Mk4i modules, by using the Mk4iSwerveModuleHelper class.
 
     // By default we will use Falcon 500s in standard configuration. But if you use a different configuration or motors
     // you MUST change it. If you do not, your code will crash on startup.


### PR DESCRIPTION
…ot umbrellaed under the Mk4 class

My team struggled for 2 hours trying to find the correct class for the modules we had just purchased, since all the gear ratios in the Mk4 class don't match the Mk4i's. Adding a hint here I think will save time for everybody.